### PR TITLE
Setup CODEOWNERS to identify who can approve a PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Group 16 Team Members
+* geissler@vt.edu goband@gmail.com shanepaulryan@vt.edu


### PR DESCRIPTION
Added teammates by email.